### PR TITLE
feat(proxy) frame size and fragment count limits

### DIFF
--- a/lib/resty/websocket/proxy.lua
+++ b/lib/resty/websocket/proxy.lua
@@ -57,6 +57,21 @@ function _M.new(opts)
         error("opts.recv_timeout must be a number", 2)
     end
 
+    if opts.max_frame_size ~= nil
+       and (type(opts.max_frame_size) ~= "number"
+            or opts.max_frame_size < 1)
+    then
+        error("opts.max_frame_size must be a number >= 1", 2)
+    end
+
+    if opts.max_fragments ~= nil
+       and (type(opts.max_fragments) ~= "number"
+            or opts.max_fragments < 1)
+    then
+        error("opts.max_fragments must be a number >= 1", 2)
+    end
+
+
     -- TODO: provide a means of passing options through to the
     -- resty.websocket.client constructor (like `max_payload_len`)
     local client, err = ws_client:new()
@@ -70,6 +85,8 @@ function _M.new(opts)
         upstream_uri = nil,
         on_frame = opts.on_frame,
         recv_timeout = opts.recv_timeout,
+        max_frame_size = opts.max_frame_size,
+        max_fragments = opts.max_fragments,
         aggregate_fragments = opts.aggregate_fragments,
         debug = opts.debug,
         client_state = _STATES.INIT,
@@ -89,13 +106,48 @@ function _M:dd(...)
 end
 
 
+local function send_close_frame(self, ws, role, code, data)
+    self:dd(role, fmt(" closing:\ncode: %s\nreason: %q", code, data))
+
+    local ok, err = ws:send_close(code, data)
+    if not ok then
+        log(ngx.ERR, "failed sending close frame to ", role, ": ", err)
+    end
+end
+
+
+local function close(self, role, code, data, peer_code, peer_data)
+    local self_ws, peer_ws
+    local self_state = role .. "_state"
+    local peer
+
+    if role == "client" then
+        self_ws = self.server
+        peer_ws = self.client
+        peer = "upstream"
+    else
+        -- role == "upstream"
+        self_ws = self.client
+        peer_ws = self.server
+        peer = "client"
+    end
+
+    send_close_frame(self, self_ws, role, code, data)
+    self[self_state] = _STATES.CLOSING
+    send_close_frame(self, peer_ws, peer, peer_code, peer_data)
+end
+
+
 local function forwarder(self, ctx)
     local role = ctx.role
     local buf = ctx.buf
     local self_ws, peer_ws
     local self_state, peer_state
     local frame_typ
+    local frame_size, frame_count = 0, 0
     local on_frame = self.on_frame
+    local max_frame_size = self.max_frame_size
+    local max_fragments = self.max_fragments
 
     self_state = role .. "_state"
 
@@ -208,6 +260,31 @@ local function forwarder(self, ctx)
                                or typ == "binary"
                                or typ == "continuation"
 
+            -- limits
+
+            if data_frame then
+                frame_size = frame_size + #data
+
+                if max_frame_size and frame_size > max_frame_size then
+                    log(ngx.INFO, fmt("%s frame size (%s) exceeds limit, closing",
+                                      role, frame_size))
+                    close(self, role, 1009, "Payload Too Large", 1001, "")
+
+                    return role
+                end
+
+                frame_count = frame_count + 1
+
+                if max_fragments and frame_count > max_fragments then
+                    log(ngx.INFO, fmt("%s frame count (%s) exceeds limit, closing",
+                                      role, frame_count))
+                    close(self, role, 1009, "Payload Too Large", 1001, "")
+
+                    return role
+                end
+            end
+
+
             -- fragmentation
 
             if self.aggregate_fragments and data_frame then
@@ -283,6 +360,12 @@ local function forwarder(self, ctx)
                                          role, err))
                         -- continue
                     end
+                end
+
+
+                if data_frame then
+                    frame_size = 0
+                    frame_count = 0
                 end
             end
 

--- a/t/08-limits.t
+++ b/t/08-limits.t
@@ -16,7 +16,7 @@ __DATA__
         content_by_lua_block {
             local proxy = require "resty.websocket.proxy"
 
-            local wp, err = proxy.new({ max_frame_size = 10 })
+            local wp, err = proxy.new({ client_max_frame_size = 10 })
             if not wp then
                 ngx.log(ngx.ERR, "failed creating proxy: ", err)
                 return ngx.exit(444)
@@ -65,7 +65,7 @@ qr/frame type: close, payload: ""/
         content_by_lua_block {
             local proxy = require "resty.websocket.proxy"
 
-            local wp, err = proxy.new({ max_frame_size = 10 })
+            local wp, err = proxy.new({ upstream_max_frame_size = 10 })
             if not wp then
                 ngx.log(ngx.ERR, "failed creating proxy: ", err)
                 return ngx.exit(444)
@@ -142,7 +142,7 @@ qr/frame type: close, payload: "Payload Too Large"/
             local proxy = require "resty.websocket.proxy"
 
             local wp, err = proxy.new({
-                max_frame_size = 10,
+                client_max_frame_size = 10,
                 aggregate_fragments = true,
             })
             if not wp then
@@ -234,7 +234,7 @@ qr/frame type: close, payload: ""/
 
             local wp, err = proxy.new({
                 aggregate_fragments = true,
-                max_frame_size = 10
+                upstream_max_frame_size = 10
             })
             if not wp then
                 ngx.log(ngx.ERR, "failed creating proxy: ", err)
@@ -317,7 +317,10 @@ qr/frame type: close, payload: "Payload Too Large", code: 1009/
         content_by_lua_block {
             local proxy = require "resty.websocket.proxy"
 
-            local wp, err = proxy.new({ max_frame_size = 2 })
+            local wp, err = proxy.new({
+                    client_max_frame_size = 2,
+                    upstream_max_frame_size = 2,
+            })
             if not wp then
                 ngx.log(ngx.ERR, "failed creating proxy: ", err)
                 return ngx.exit(444)
@@ -394,7 +397,7 @@ qr/.*?frame type: ping, payload: "test-1".*
             local proxy = require "resty.websocket.proxy"
 
             local wp, err = proxy.new({
-                max_fragments = 5,
+                client_max_fragments = 5,
                 aggregate_fragments = true,
                 debug = true,
             })
@@ -487,7 +490,7 @@ qr/frame type: close, payload: ""/
 
             local wp, err = proxy.new({
                 aggregate_fragments = true,
-                max_fragments = 5,
+                upstream_max_fragments = 5,
             })
             if not wp then
                 ngx.log(ngx.ERR, "failed creating proxy: ", err)

--- a/t/08-limits.t
+++ b/t/08-limits.t
@@ -1,0 +1,562 @@
+# vim:set ts=4 sts=4 sw=4 et ft=:
+
+use lib '.';
+use t::Tests;
+
+plan tests => repeat_each() * (blocks() * 4);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: limiting individual frame size (client)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({ max_frame_size = 10 })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local ok, err = wp:connect(proxy._tests.echo .. "?repeat=1")
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+            assert(wb:send_text("this is way too long"))
+            local data, typ, err = wb:recv_frame()
+            ngx.say(string.format("data: %q, typ: %s, err: %s", data, typ, err))
+        }
+    }
+--- response_body
+data: "Payload Too Large", typ: close, err: 1009
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: ""/
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: limiting individual frame size (upstream)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({ max_frame_size = 10 })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/upstream"
+            local ok, err = wp:connect(uri)
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /upstream {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed creating server: ", err)
+                return ngx.exit(444)
+            end
+
+            local bytes, err = wb:send_text("this is way too long")
+            if not bytes then
+                ngx.log(ngx.ERR, "failed sending frame: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "frame type: ", typ, ", payload: \"", data, "\"")
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+            assert(wb:send_text("hello"))
+            local data, typ, err = wb:recv_frame()
+            ngx.say(string.format("data: %q, typ: %s, err: %s", data, typ, err))
+        }
+    }
+--- response_body
+data: "", typ: close, err: 1001
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: "Payload Too Large"/
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: limiting aggregated frame size (client)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({
+                max_frame_size = 10,
+                aggregate_fragments = true,
+            })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local ok, err = wp:connect(proxy._tests.pong .. "?repeat=1")
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+
+            local fmt = string.format
+
+            local function ping_pong(i)
+                local bytes, err = wb:send_ping(i)
+                if not bytes then
+                    return nil, fmt("send failed: %s", err)
+                end
+
+                local data, typ, err = wb:recv_frame()
+                if not data then
+                    return nil, fmt("recv failed: %s", err)
+                elseif typ ~= "pong" then
+                    return nil, fmt("unexpected frame %s => %q", typ, data)
+                end
+
+                return true
+            end
+
+            for i = 1, 5 do
+                local opcode = (i == 1 and 0x1) or 0x0
+                local bytes, err = wb:send_frame(false, opcode, "11")
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed sending fragment ", i, ": ", err)
+                    return ngx.exit(500)
+                end
+
+                local ok, err = ping_pong(i)
+                if not ok then
+                    ngx.log(ngx.ERR, "failed ping-pong: ", err)
+                    return ngx.exit(500)
+                end
+            end
+
+            local bytes, err = wb:send_frame(false, 0x0, "1")
+            if not bytes then
+                ngx.log(ngx.ERR, "failed sending final fragment: ", err)
+                return ngx.exit(500)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            ngx.say(string.format("data: %q, typ: %s, err: %s", data, typ, err))
+        }
+    }
+--- response_body
+data: "Payload Too Large", typ: close, err: 1009
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: ""/
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: limiting aggregated frame size (upstream)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({
+                aggregate_fragments = true,
+                max_frame_size = 10
+            })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/upstream"
+            local ok, err = wp:connect(uri)
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /upstream {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed creating server: ", err)
+                return ngx.exit(444)
+            end
+
+            for i = 1, 5 do
+                local opcode = (i == 1 and 0x1) or 0x0
+                local bytes, err = wb:send_frame(false, opcode, "11")
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed sending fragment ", i, ": ", err)
+                    return ngx.exit(444)
+                end
+            end
+
+            local bytes, err = wb:send_frame(false, 0x0, "1")
+            if not bytes then
+                ngx.log(ngx.ERR, "failed sending final fragment: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            ngx.log(ngx.INFO, "frame type: ", typ, ", payload: \"", data, "\", code: ", err)
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+            repeat
+                local data, typ, err = wb:recv_frame()
+                ngx.say(string.format("data: %q, typ: %s, err: %s",
+                                      data, typ, err))
+            until typ == "close" or not data
+        }
+    }
+--- response_body
+data: "", typ: close, err: 1001
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: "Payload Too Large", code: 1009/
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: control frames are not subject to max_frame_size
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({ max_frame_size = 2 })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local ok, err = wp:connect(proxy._tests.pong .. "?repeat=1")
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+
+            for i = 1, 2 do
+                local sent, err = wb:send_ping("test-" .. i)
+                if not sent then
+                    ngx.log(ngx.ERR, "failed sending ping: ", err)
+                    return ngx.exit(500)
+                end
+
+                local data, typ, err = wb:recv_frame()
+                if not data then
+                    ngx.log(ngx.ERR, "failed to receive pong: ", err)
+                    return ngx.exit(500)
+
+                elseif typ ~= "pong" then
+                    ngx.log(ngx.ERR, "unexpecting response to ping: ", typ)
+                    return ngx.exit(500)
+
+                elseif #data <= 2 then
+                    ngx.log(ngx.ERR, "broken test--pong frame is too short")
+                    return ngx.exit(500)
+                end
+
+                ngx.say(string.format("data: %q, typ: %s", data, typ))
+            end
+
+            assert(wb:send_close(1002, "goodbye"))
+        }
+    }
+--- response_body
+data: "heartbeat server", typ: pong
+data: "heartbeat server", typ: pong
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/.*?frame type: ping, payload: "test-1".*
+.*?frame type: ping, payload: "test-2".*
+.*?forwarding close with code: 1002.*
+.*?frame type: close, payload: "goodbye".*/
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: limiting the number of fragments (client)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({
+                max_fragments = 5,
+                aggregate_fragments = true,
+                debug = true,
+            })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local ok, err = wp:connect(proxy._tests.pong .. "?repeat=1")
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+
+            local fmt = string.format
+
+            local function ping_pong(i)
+                local bytes, err = wb:send_ping(i)
+                if not bytes then
+                    return nil, fmt("send failed: %s", err)
+                end
+
+                local data, typ, err = wb:recv_frame()
+                if not data then
+                    return nil, fmt("recv failed: %s", err)
+                elseif typ ~= "pong" then
+                    return nil, fmt("unexpected frame %s => %q", typ, data)
+                end
+
+                return true
+            end
+
+            for i = 1, 5 do
+                local opcode = (i == 1 and 0x1) or 0x0
+                local bytes, err = wb:send_frame(false, opcode, "11")
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed sending fragment ", i, ": ", err)
+                    return ngx.exit(500)
+                end
+
+                local ok, err = ping_pong(i)
+                if not ok then
+                    ngx.log(ngx.ERR, "failed ping-pong: ", err)
+                    return ngx.exit(500)
+                end
+            end
+
+            local bytes, err = wb:send_frame(false, 0x0, "1")
+            if not bytes then
+                ngx.log(ngx.ERR, "failed sending final fragment: ", err)
+                return ngx.exit(500)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            ngx.say(string.format("data: %q, typ: %s, err: %s", data, typ, err))
+        }
+    }
+--- response_body
+data: "Payload Too Large", typ: close, err: 1009
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: ""/
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: limiting the number of fragments (upstream)
+--- http_config eval: $t::Tests::HttpConfig
+--- config
+    location /proxy {
+        content_by_lua_block {
+            local proxy = require "resty.websocket.proxy"
+
+            local wp, err = proxy.new({
+                aggregate_fragments = true,
+                max_fragments = 5,
+            })
+            if not wp then
+                ngx.log(ngx.ERR, "failed creating proxy: ", err)
+                return ngx.exit(444)
+            end
+
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/upstream"
+            local ok, err = wp:connect(uri)
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return ngx.exit(444)
+            end
+
+            local done, err = wp:execute()
+            if not done then
+                ngx.log(ngx.ERR, "failed proxying: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+
+    location /upstream {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed creating server: ", err)
+                return ngx.exit(444)
+            end
+
+            for i = 1, 5 do
+                local opcode = (i == 1 and 0x1) or 0x0
+                local bytes, err = wb:send_frame(false, opcode, "11")
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed sending fragment ", i, ": ", err)
+                    return ngx.exit(444)
+                end
+            end
+
+            local bytes, err = wb:send_frame(false, 0x0, "1")
+            if not bytes then
+                ngx.log(ngx.ERR, "failed sending final fragment: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            ngx.log(ngx.INFO, "frame type: ", typ, ", payload: \"", data, "\", code: ", err)
+        }
+    }
+
+    location /t {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb = assert(client:new())
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/proxy"
+
+            assert(wb:connect(uri))
+            repeat
+                local data, typ, err = wb:recv_frame()
+                ngx.say(string.format("data: %q, typ: %s, err: %s",
+                                      data, typ, err))
+            until typ == "close" or not data
+        }
+    }
+--- response_body
+data: "", typ: close, err: 1001
+--- grep_error_log eval: qr/\[lua\].*/
+--- grep_error_log_out eval
+qr/frame type: close, payload: "Payload Too Large", code: 1009/
+--- no_error_log
+[error]


### PR DESCRIPTION
Notable Changes:

* proxy: new `client_max_frame_size`/`upstream_max_frame_size` option (applies to singular and aggregated frames) limits frame size
* proxy: new `client_max_fragments`/`upstream_max_fragments` option limits the number of buffered fragments
* tests: added a `repeat` query arg to the server fixtures that causes the server to loop until calls to `recv_frame()` time out or return a close frame (~might be okay to make this the default behavior~ nope, it breaks tests)

Both of the limits cause a close frame with status `1009` and reason `Payload Too Large` (copied from HTTP 413) to be sent to the source of the offending frame. The peer websocket is sent a `1001` ("going away") close frame with no payload. These things are hard-coded now but can be made configurable if desired.

Closes #10