### PR TITLE
feat(proxy) return upstream response on failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "misc/lua-resty-websocket"]
 	path = misc/lua-resty-websocket
-	url = git@github.com:openresty/lua-resty-websocket.git
+	url = git@github.com:Kong/lua-resty-websocket.git

--- a/lib/resty/websocket/proxy.lua
+++ b/lib/resty/websocket/proxy.lua
@@ -307,7 +307,7 @@ function _M:connect_upstream(uri, opts)
 
     local ok, err, res = self.client:connect(uri, opts)
     if not ok then
-        return nil, err
+        return nil, err, res
     end
 
     self:dd("connected to \"", uri, "\" upstream")


### PR DESCRIPTION
This allows callers of `proxy:connect_upstream()` the ability to parse the HTTP status and headers from the response (if desired) even when there's an HTTP-level failure.

Note that response status code check is only a `Kong/lua-resty-websocket` [feature](https://github.com/Kong/lua-resty-websocket/pull/6) at the moment, so properly testing this code path is only possible if using `Kong/lua-resty-websocket`. I wanted to err on the side of having a test, so I updated the submodule to point there. That said, this is a really minor change, so if it's undesirable to test against Kong's resty-websocket fork instead of upstream OpenResty, then I _think_ it would be fine to simply remove the test case and revert the submodule back to `openresty/lua-resty-websocket`.